### PR TITLE
BFF層のサンプルコードを作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "next": "^9.3.4",
+    "nookies": "^2.2.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "styled-components": "^5.1.0"

--- a/src/infrastructure/Cookie.ts
+++ b/src/infrastructure/Cookie.ts
@@ -1,0 +1,36 @@
+import {
+  parseCookies,
+  setCookie as nookiesSetCookie,
+  destroyCookie as nookiesDestroyCookie,
+} from 'nookies';
+import { NextPageContext } from 'next';
+
+export const findCookies = <T>(ctx?: NextPageContext): T => {
+  const cookies: {} = parseCookies(ctx);
+
+  return cookies as T;
+};
+
+type SetCookieParams = {
+  key: string;
+  value: string;
+};
+
+export const setCookie = (params: SetCookieParams, ctx?: NextPageContext) => {
+  // TODO 以下を参考に外からoptionsを設定可能にする
+  // https://github.com/maticzav/nookies#setcookiectx-name-value-options-or-cookiessetctx-name-value-options
+  nookiesSetCookie(ctx, params.key, params.value, {
+    path: '/',
+  });
+};
+
+type DestroyCookieParams = {
+  key: string;
+};
+
+export const destroyCookie = (
+  ctx: NextPageContext,
+  params: DestroyCookieParams,
+) => {
+  nookiesDestroyCookie(ctx, params.key);
+};

--- a/src/infrastructure/Cookie.ts
+++ b/src/infrastructure/Cookie.ts
@@ -21,6 +21,7 @@ export const setCookie = (params: SetCookieParams, ctx?: NextPageContext) => {
   // https://github.com/maticzav/nookies#setcookiectx-name-value-options-or-cookiessetctx-name-value-options
   nookiesSetCookie(ctx, params.key, params.value, {
     path: '/',
+    httpOnly: true,
   });
 };
 

--- a/src/pages/api/users.ts
+++ b/src/pages/api/users.ts
@@ -1,0 +1,27 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+type User = {
+  id: number;
+  name: string;
+};
+
+type UserResponse = {
+  users?: User[];
+  error?: {
+    code: number;
+    message: string;
+  };
+};
+
+export default (_req: NextApiRequest, res: NextApiResponse<UserResponse>) => {
+  const users = [
+    { id: 1, name: 'Moko' },
+    { id: 2, name: 'Mop' },
+  ];
+
+  const userResponse = {
+    users,
+  };
+
+  return res.status(200).json(userResponse);
+};

--- a/src/pages/api/users/[userId].ts
+++ b/src/pages/api/users/[userId].ts
@@ -1,0 +1,44 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+type User = {
+  id: number;
+  name: string;
+};
+
+type UserResponse = {
+  user?: User;
+  error?: {
+    code: number;
+    message: string;
+  };
+};
+
+export default (req: NextApiRequest, res: NextApiResponse<UserResponse>) => {
+  const userId: number = parseInt(req.query.userId as string, 10);
+
+  const users = [
+    { id: 1, name: 'Moko' },
+    { id: 2, name: 'Mop' },
+  ];
+
+  const responseUser = users.filter((user: User) => {
+    return user.id === userId;
+  });
+
+  if (responseUser.length === 0) {
+    const responseBody = {
+      error: {
+        code: 400,
+        message: 'Not Found',
+      },
+    };
+
+    return res.status(404).json(responseBody);
+  }
+
+  const responseBody = {
+    user: responseUser[0],
+  };
+
+  return res.status(200).json(responseBody);
+};

--- a/src/pages/auth.tsx
+++ b/src/pages/auth.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { NextPageContext } from 'next';
+import { setCookie } from '../infrastructure/Cookie';
+
+type Props = {
+  authToken: string;
+};
+
+const AuthPage: React.FC<Props> = ({ authToken }: Props) => {
+  return <p>Auth Token is... {authToken}</p>;
+};
+
+export const getServerSideProps = async (ctx: NextPageContext) => {
+  const authToken: string = Math.random().toString(32).substring(2);
+
+  setCookie({ key: 'authToken', value: authToken }, ctx);
+
+  return {
+    props: {
+      authToken,
+    },
+  };
+};
+
+export default AuthPage;

--- a/src/pages/auth.tsx
+++ b/src/pages/auth.tsx
@@ -1,13 +1,29 @@
 import React from 'react';
 import { NextPageContext } from 'next';
+import Link from 'next/link';
+import styled from 'styled-components';
 import { setCookie } from '../infrastructure/Cookie';
 
 type Props = {
   authToken: string;
 };
 
+const StyledLink = styled.a`
+  color: blue;
+  text-decoration: underline;
+`;
+
 const AuthPage: React.FC<Props> = ({ authToken }: Props) => {
-  return <p>Auth Token is... {authToken}</p>;
+  return (
+    <>
+      <p>Set Auth Token in a Cookie AuthToken is...[{authToken}]</p>
+      <p>
+        <Link href="/authed">
+          <StyledLink>Go To authed Page.</StyledLink>
+        </Link>
+      </p>
+    </>
+  );
 };
 
 export const getServerSideProps = async (ctx: NextPageContext) => {

--- a/src/pages/authed.tsx
+++ b/src/pages/authed.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { NextPageContext } from 'next';
+import { findCookies } from '../infrastructure/Cookie';
+
+type Props = {
+  authToken: string;
+};
+
+const AuthedPage: React.FC<Props> = ({ authToken }: Props) => {
+  return (
+    <>
+      {authToken ? (
+        <p>Auth Token in the Cookie is... {authToken}</p>
+      ) : (
+        <p>There is no AuthToken in the cookie.</p>
+      )}
+    </>
+  );
+};
+
+export const getServerSideProps = async (ctx: NextPageContext) => {
+  const cookies = findCookies<Props>(ctx);
+  const authToken = cookies.authToken ?? '';
+
+  return {
+    props: {
+      authToken,
+    },
+  };
+};
+
+export default AuthedPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4846,6 +4846,11 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
+cookie@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
 copy-concurrently@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
@@ -8820,6 +8825,11 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
+jsmin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jsmin/-/jsmin-1.0.1.tgz#e7bd0dcd6496c3bf4863235bf461a3d98aa3b98c"
+  integrity sha1-570NzWSWw79IYyNb9GGj2YqjuYw=
+
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -9953,6 +9963,15 @@ node-releases@^1.1.29, node-releases@^1.1.44, node-releases@^1.1.53:
   version "1.1.53"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
   integrity sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==
+
+nookies@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/nookies/-/nookies-2.2.3.tgz#72b125fb7c5c7496e047a61d23b720bc4f06ceca"
+  integrity sha512-RreLycbVlkI2pkJ4Ntq2gKM10xKhDL0ukofXIiUvWyS8kQ1c2+fYC20J3bu94VUFfJbsS5gDlJw57Buh79+idg==
+  dependencies:
+    cookie "^0.4.0"
+    jsmin "^1.0.1"
+    set-cookie-parser "^2.4.3"
 
 normalize-html-whitespace@1.0.0:
   version "1.0.0"
@@ -12447,6 +12466,11 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-cookie-parser@^2.4.3:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.4.5.tgz#94a5060724e614c56c65588010594dc4b848fb8d"
+  integrity sha512-LkSDwseogN5l6TerqGzFzL9mUDTxSq3hX2b5AaynjC1nSCNWiDypEgHatfc0v6KcnfgV3/6F6h4ABh6igjzlQQ==
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-frontend/issues/3

# 関連URL
- http://localhost:3000/api/users
- http://localhost:3000/api/users/1
- http://localhost:3000/auth
- http://localhost:3000/authed

# Doneの定義
- BFF層にAPIのエンドポイントが実装されている事
- Cookieを扱うエンドポイントが実装されている事

# 変更点概要

以下の仮実装を追加しBFF層が実装出来る事を確認。

## API用のエンドポイントを用意

http://localhost:3000/api/users

```
{"users":[{"id":1,"name":"Moko"},{"id":2,"name":"Mop"}]}
```

http://localhost:3000/api/users/1

```
{"user":{"id":1,"name":"Moko"}}
```

## Cookieを扱う為のページを作成

### Cookieを設定するページ
http://localhost:3000/auth

### 設定しているCookieの中身を取り出しているページ
http://localhost:3000/authed

# 補足情報
本格的に開発を始めてみると問題が起こる可能性はあるが、基本的にカスタムサーバーを使わなくても標準の仕組みで十分に開発が可能だと思う。（環境構築が特殊になるので出来ればカスタムサーバーは避けたい）

下記の記事にあるように以下の3つの機能を上手く使い分けていく必要がありそう。

- getStaticProps
- getStaticPaths
- getServerSideProps

https://qiita.com/matamatanot/items/1735984f40540b8bdf91#next-export