### PR TITLE
Reduxを導入

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "nookies": "^2.2.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-redux": "^7.2.0",
+    "redux": "^4.0.5",
+    "redux-logger": "^3.0.6",
     "styled-components": "^5.1.0"
   },
   "devDependencies": {
@@ -37,7 +40,9 @@
     "@types/prettier": "^2.0.0",
     "@types/react": "^16.9.34",
     "@types/react-dom": "^16.9.6",
+    "@types/react-redux": "^7.1.7",
     "@types/react-test-renderer": "^16.9.2",
+    "@types/redux-logger": "^3.0.7",
     "@types/storybook__addon-info": "^5.2.1",
     "@types/storybook__addon-storyshots": "^5.3.1",
     "@types/storybook__react": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:storybook": "build-storybook -o build/storybook"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^1.3.5",
     "next": "^9.3.4",
     "nookies": "^2.2.3",
     "react": "^16.13.1",

--- a/src/ducks/ReduxAction.d.ts
+++ b/src/ducks/ReduxAction.d.ts
@@ -17,12 +17,15 @@ interface FulfilledAction<ThunkArg, T> {
 
 interface RejectedAction<ThunkArg> {
   type: string;
-  error: {
-    name?: string;
-    message?: string;
-    code?: string;
-    stack?: string;
-  };
+  /* eslint @typescript-eslint/no-explicit-any: 0 */
+  error:
+    | {
+        name?: string;
+        message?: string;
+        code?: string;
+        stack?: string;
+      }
+    | any;
   meta: {
     requestId: string;
     arg: ThunkArg;

--- a/src/ducks/ReduxAction.d.ts
+++ b/src/ducks/ReduxAction.d.ts
@@ -1,0 +1,31 @@
+interface PendingAction<ThunkArg> {
+  type: string;
+  meta: {
+    requestId: string;
+    arg: ThunkArg;
+  };
+}
+
+interface FulfilledAction<ThunkArg, T> {
+  type: string;
+  payload: T;
+  meta: {
+    requestId: string;
+    arg: ThunkArg;
+  };
+}
+
+interface RejectedAction<ThunkArg> {
+  type: string;
+  error: {
+    name?: string;
+    message?: string;
+    code?: string;
+    stack?: string;
+  };
+  meta: {
+    requestId: string;
+    arg: ThunkArg;
+    aborted: boolean;
+  };
+}

--- a/src/ducks/counter/asyncActions.ts
+++ b/src/ducks/counter/asyncActions.ts
@@ -8,6 +8,11 @@ export const asyncIncrementCounter = createAsyncThunk<number, number>(
   async (arg: number): Promise<number> => {
     await sleep(1000);
 
+    const randNum = Math.floor(Math.random() * Math.floor(10));
+    if (randNum === 0 || randNum === 5 || randNum === 1) {
+      return Promise.reject(new Error('asyncIncrementCounter error'));
+    }
+
     return arg;
   },
 );

--- a/src/ducks/counter/asyncActions.ts
+++ b/src/ducks/counter/asyncActions.ts
@@ -1,0 +1,13 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+const sleep = (microSecond: number) =>
+  new Promise((resolve) => setTimeout(resolve, microSecond));
+
+export const asyncIncrementCounter = createAsyncThunk<number, number>(
+  'counter/asyncIncrementCounter',
+  async (arg: number): Promise<number> => {
+    await sleep(1000);
+
+    return arg;
+  },
+);

--- a/src/ducks/counter/selectors.ts
+++ b/src/ducks/counter/selectors.ts
@@ -1,0 +1,6 @@
+import { useSelector } from 'react-redux';
+import { CounterState } from './slice';
+
+export const useCounterState = () => {
+  return useSelector((state: { counter: CounterState }) => state);
+};

--- a/src/ducks/counter/slice.ts
+++ b/src/ducks/counter/slice.ts
@@ -1,12 +1,14 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { useSelector } from 'react-redux';
+import { asyncIncrementCounter } from './asyncActions';
 
 export type CounterState = {
   count: number;
+  loading: boolean;
 };
 
 export const initialState: CounterState = {
   count: 0,
+  loading: false,
 };
 
 const counterSlice = createSlice({
@@ -22,10 +24,24 @@ const counterSlice = createSlice({
       count: state.count - action.payload,
     }),
   },
+  extraReducers: (builder) => {
+    builder.addCase(asyncIncrementCounter.pending, (state) => {
+      return {
+        ...state,
+        loading: true,
+      };
+    });
+    builder.addCase(
+      asyncIncrementCounter.fulfilled,
+      (state, action: PayloadAction<number>) => {
+        return {
+          ...state,
+          count: state.count + action.payload,
+          loading: false,
+        };
+      },
+    );
+  },
 });
-
-export const useCounterState = () => {
-  return useSelector((state: { counter: CounterState }) => state);
-};
 
 export default counterSlice;

--- a/src/ducks/counter/slice.ts
+++ b/src/ducks/counter/slice.ts
@@ -4,11 +4,15 @@ import { asyncIncrementCounter } from './asyncActions';
 export type CounterState = {
   count: number;
   loading: boolean;
+  error: boolean;
+  errorMessage: string;
 };
 
 export const initialState: CounterState = {
   count: 0,
   loading: false,
+  error: false,
+  errorMessage: '',
 };
 
 const counterSlice = createSlice({
@@ -29,8 +33,21 @@ const counterSlice = createSlice({
       return {
         ...state,
         loading: true,
+        error: false,
+        errorMessage: '',
       };
     });
+    builder.addCase(
+      asyncIncrementCounter.rejected,
+      (state, action: RejectedAction<number>) => {
+        return {
+          ...state,
+          loading: false,
+          error: true,
+          errorMessage: action.error.message,
+        };
+      },
+    );
     builder.addCase(
       asyncIncrementCounter.fulfilled,
       (state, action: PayloadAction<number>) => {
@@ -38,6 +55,8 @@ const counterSlice = createSlice({
           ...state,
           count: state.count + action.payload,
           loading: false,
+          error: false,
+          errorMessage: '',
         };
       },
     );

--- a/src/ducks/counter/slice.ts
+++ b/src/ducks/counter/slice.ts
@@ -1,0 +1,31 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { useSelector } from 'react-redux';
+
+export type CounterState = {
+  count: number;
+};
+
+export const initialState: CounterState = {
+  count: 0,
+};
+
+const counterSlice = createSlice({
+  name: 'counter',
+  initialState,
+  reducers: {
+    incrementCounter: (state, action: PayloadAction<number>) => ({
+      ...state,
+      count: state.count + action.payload,
+    }),
+    decrementCounter: (state, action: PayloadAction<number>) => ({
+      ...state,
+      count: state.count - action.payload,
+    }),
+  },
+});
+
+export const useCounterState = () => {
+  return useSelector((state: { counter: CounterState }) => state);
+};
+
+export default counterSlice;

--- a/src/ducks/createStore.ts
+++ b/src/ducks/createStore.ts
@@ -18,14 +18,12 @@ export type ReduxStoreInstance = Store<StoreState>;
 const createStore = () => {
   const middlewareList = [...getDefaultMiddleware(), logger];
 
-  const store = configureStore({
+  return configureStore({
     reducer: rootReducer,
     middleware: middlewareList,
     devTools: process.env.NODE_ENV !== 'production',
     preloadedState: preloadedState(),
   });
-
-  return store;
 };
 
 export default createStore;

--- a/src/ducks/createStore.ts
+++ b/src/ducks/createStore.ts
@@ -1,0 +1,31 @@
+import { Store, combineReducers } from 'redux';
+import logger from 'redux-logger';
+import { configureStore, getDefaultMiddleware } from '@reduxjs/toolkit';
+import counterSlice, { initialState as counterState } from './counter/slice';
+
+const rootReducer = combineReducers({
+  counter: counterSlice.reducer,
+});
+
+const preloadedState = () => {
+  return { counter: counterState };
+};
+
+export type StoreState = ReturnType<typeof preloadedState>;
+
+export type ReduxStoreInstance = Store<StoreState>;
+
+const createStore = () => {
+  const middlewareList = [...getDefaultMiddleware(), logger];
+
+  const store = configureStore({
+    reducer: rootReducer,
+    middleware: middlewareList,
+    devTools: process.env.NODE_ENV !== 'production',
+    preloadedState: preloadedState(),
+  });
+
+  return store;
+};
+
+export default createStore;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { AppProps } from 'next/app';
+import { Provider } from 'react-redux';
+import createStore from '../ducks/createStore';
+
+const kimonoApp = ({ Component, pageProps }: AppProps) => {
+  return (
+    <Provider store={createStore()}>
+      <Component {...pageProps} />
+    </Provider>
+  );
+};
+
+export default kimonoApp;

--- a/src/pages/counter.tsx
+++ b/src/pages/counter.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
+import styled from 'styled-components';
 import counterSlice from '../ducks/counter/slice';
 import { useCounterState } from '../ducks/counter/selectors';
 import { asyncIncrementCounter } from '../ducks/counter/asyncActions';
+
+const StyledMessage = styled.p`
+  color: red;
+  font-weight: bold;
+`;
 
 const CounterPage: React.FC = () => {
   const dispatch = useDispatch();
@@ -37,6 +43,11 @@ const CounterPage: React.FC = () => {
       </button>
       <p>ねこが{useCounterState().counter.count} 匹いる</p>
       {state.loading ? <p>通信中</p> : ''}
+      {state.error ? (
+        <StyledMessage>問題が発生しました。{state.errorMessage}</StyledMessage>
+      ) : (
+        ''
+      )}
     </>
   );
 };

--- a/src/pages/counter.tsx
+++ b/src/pages/counter.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import counterSlice, { useCounterState } from '../ducks/counter/slice';
+
+const CounterPage: React.FC = () => {
+  const dispatch = useDispatch();
+
+  const onClickIncrement = () => {
+    dispatch(counterSlice.actions.incrementCounter(1));
+  };
+
+  const onClickDecrement = () => {
+    dispatch(counterSlice.actions.decrementCounter(1));
+  };
+
+  return (
+    <>
+      <button type="button" onClick={onClickIncrement}>
+        ふやす
+      </button>
+      <button type="button" onClick={onClickDecrement}>
+        へらす
+      </button>
+      <p>ねこが{useCounterState().counter.count} 匹いる</p>
+    </>
+  );
+};
+
+export default CounterPage;

--- a/src/pages/counter.tsx
+++ b/src/pages/counter.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import counterSlice, { useCounterState } from '../ducks/counter/slice';
+import counterSlice from '../ducks/counter/slice';
+import { useCounterState } from '../ducks/counter/selectors';
+import { asyncIncrementCounter } from '../ducks/counter/asyncActions';
 
 const CounterPage: React.FC = () => {
   const dispatch = useDispatch();
+  const state = useCounterState().counter;
 
   const onClickIncrement = () => {
     dispatch(counterSlice.actions.incrementCounter(1));
@@ -11,6 +14,10 @@ const CounterPage: React.FC = () => {
 
   const onClickDecrement = () => {
     dispatch(counterSlice.actions.decrementCounter(1));
+  };
+
+  const onClickAsyncIncrement = async () => {
+    await dispatch(asyncIncrementCounter(10));
   };
 
   return (
@@ -21,7 +28,15 @@ const CounterPage: React.FC = () => {
       <button type="button" onClick={onClickDecrement}>
         へらす
       </button>
+      <button
+        type="button"
+        onClick={onClickAsyncIncrement}
+        disabled={state.loading}
+      >
+        非同期でふやす
+      </button>
       <p>ねこが{useCounterState().counter.count} 匹いる</p>
+      {state.loading ? <p>通信中</p> : ''}
     </>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1687,6 +1687,16 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
+"@reduxjs/toolkit@^1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.3.5.tgz#37c1ab6de9aa66f95bab25a8e9bd9d8ec3b7b80c"
+  integrity sha512-QVqI2T6kwT/3CVdCa6KjUDdEz9YY1eCLQVcRZamiaOAcKI7kkJSh2P0GjaaKXTjIFy0u9sWCXjzifPJNGoXjlw==
+  dependencies:
+    immer "^6.0.1"
+    redux "^4.0.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
+
 "@sinonjs/commons@^1.7.0":
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.2.tgz#505f55c74e0272b43f6c52d81946bed7058fc0e2"
@@ -7486,6 +7496,11 @@ immer@1.10.0:
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
   integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
 
+immer@^6.0.1:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-6.0.3.tgz#94d5051cd724668160a900d66d85ec02816f29bd"
+  integrity sha512-12VvNrfSrXZdm/BJgi/KDW2soq5freVSf3I1+4CLunUM8mAGx2/0Njy0xBVzi5zewQZiwM7z1/1T+8VaI7NkmQ==
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -11774,7 +11789,12 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-redux@^4.0.1:
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
+redux@^4.0.0, redux@^4.0.1:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
   integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
@@ -12110,6 +12130,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 resize-observer-polyfill@^1.5.1:
   version "1.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2359,7 +2359,7 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.5.tgz#527d20ef68571a4af02ed74350164e7a67544860"
   integrity sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw==
 
-"@types/hoist-non-react-statics@*":
+"@types/hoist-non-react-statics@*", "@types/hoist-non-react-statics@^3.3.0":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
   integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
@@ -2508,6 +2508,16 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-redux@^7.1.7":
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.7.tgz#12a0c529aba660696947384a059c5c6e08185c7a"
+  integrity sha512-U+WrzeFfI83+evZE2dkZ/oF/1vjIYgqrb5dGgedkqVV8HEfDFujNgWCwHL89TDuWKb47U0nTBT6PLGq4IIogWg==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
+
 "@types/react-syntax-highlighter@11.0.4":
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz#d86d17697db62f98046874f62fdb3e53a0bbc4cd"
@@ -2536,6 +2546,13 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/redux-logger@^3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/redux-logger/-/redux-logger-3.0.7.tgz#163f6f6865c69c21d56f9356dc8d741718ec0db0"
+  integrity sha512-oV9qiCuowhVR/ehqUobWWkXJjohontbDGLV88Be/7T4bqMQ3kjXwkFNL7doIIqlbg3X2PC5WPziZ8/j/QHNQ4A==
+  dependencies:
+    redux "^3.6.0"
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -5282,6 +5299,11 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+deep-diff@^0.3.5:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
+  integrity sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=
 
 deep-equal@^1.1.1:
   version "1.1.1"
@@ -9113,6 +9135,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash-es@^4.2.1:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -9148,7 +9175,7 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
-lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
+lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.2.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -11523,7 +11550,7 @@ react-popper@^1.3.7:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-redux@^7.0.2:
+react-redux@^7.0.2, react-redux@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.0.tgz#f970f62192b3981642fec46fd0db18a074fe879d"
   integrity sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==
@@ -11789,12 +11816,29 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-logger@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
+  integrity sha1-91VZZvMJjzyIYExEnPC69XeCdL8=
+  dependencies:
+    deep-diff "^0.3.5"
+
 redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
   integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
-redux@^4.0.0, redux@^4.0.1:
+redux@^3.6.0:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
+  integrity sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==
+  dependencies:
+    lodash "^4.2.1"
+    lodash-es "^4.2.1"
+    loose-envify "^1.1.0"
+    symbol-observable "^1.0.3"
+
+redux@^4.0.0, redux@^4.0.1, redux@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
   integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
@@ -13428,7 +13472,7 @@ svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-symbol-observable@^1.2.0:
+symbol-observable@^1.0.3, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-frontend/issues/8

# 関連URL
http://localhost:3000/counter

# Doneの定義
- Reduxが導入されサンプルコードが実装されている事

# スクリーンショット

以下のようなページを実装、非同期処理のActionに関してもサンプルを用意。

## 非同期Action成功時
<img width="211" alt="success" src="https://user-images.githubusercontent.com/11032365/81136725-59f0ac00-8f97-11ea-9f4a-92239447aa05.png">

## 非同期Action失敗時
<img width="452" alt="error" src="https://user-images.githubusercontent.com/11032365/81136734-5eb56000-8f97-11ea-93d3-a5008b6abe51.png">

# 変更点概要
- `@reduxjs/toolkit` や `redux` などのpackageを追加
- `counter` pageを実装しReduxを使ったcounterを実装

# 補足情報

## ディレクトリ構成について
Reduxのディレクトリ構成は以下の記事を参考にした。（Re-ducksパターン）

- https://hirooooo-lab.com/development/react-redux-ducks-pattern/
- https://noah.plus/blog/021/
- https://github.com/jthegedus/re-ducks-examples

最初は [Advanced Tutorial](https://redux-toolkit.js.org/tutorials/advanced-tutorial) で紹介されている [こちら](https://github.com/reduxjs/rtk-github-issues-example) を参考にしようと思ったが、Next.jsのディレクトリ構成と微妙に合わないので、Re-ducksパターンを採用する事にした。

## 非同期処理で参考にした記事

非同期処理に関しては `@reduxjs/toolkit` の機能である `createAsyncThunk` を利用する事にした。

reduxの非同期処理と言えば、`redux-saga` だがこれは割と複雑な仕組みなので、`@reduxjs/toolkit` の標準機能として提供されている `createAsyncThunk` を利用したほうがシンプルであると判断した。

- https://future-architect.github.io/articles/20200501/
- https://qiita.com/puku0x/items/4217ca9f98fad82bc998