### PR TITLE
CognitoUserPoolにログインする機能を作成する

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,12 @@ CSF（Component Story Format）で記載します。
 書き方に関しては下記のドキュメントを参照して下さい。
 
 https://storybook.js.org/docs/formats/component-story-format/
+
+## 環境変数
+
+`.env`を作成し、下記を設定してください。
+
+```
+NEXT_PUBLIC_USER_POOL_ID="ローカル環境用のUserPool ID"
+NEXT_PUBLIC_USER_POOL_WEB_CLIENT_ID="ローカル環境用のUserPoolClientID"
+```

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build:storybook": "build-storybook -o build/storybook"
   },
   "dependencies": {
+    "@aws-amplify/ui-components": "^0.5.4",
     "@aws-amplify/ui-react": "^0.2.9",
     "@reduxjs/toolkit": "^1.3.6",
     "aws-amplify": "^3.0.18",

--- a/src/ducks/account/selectors.ts
+++ b/src/ducks/account/selectors.ts
@@ -1,0 +1,6 @@
+import { useSelector } from 'react-redux';
+import { AccountState } from './slice';
+
+export const useAccountState = () => {
+  return useSelector((state: { account: AccountState }) => state);
+};

--- a/src/ducks/account/slice.ts
+++ b/src/ducks/account/slice.ts
@@ -1,0 +1,32 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export type AccountState = {
+  name: string;
+  authState: string;
+  error: boolean;
+  errorMessage: string;
+};
+
+export const initialState: AccountState = {
+  name: '',
+  authState: '',
+  error: false,
+  errorMessage: '',
+};
+
+const accountSlice = createSlice({
+  name: 'account',
+  initialState,
+  reducers: {
+    setName: (state, action: PayloadAction<string>) => ({
+      ...state,
+      name: action.payload,
+    }),
+    setAuthState: (state, action: PayloadAction<string>) => ({
+      ...state,
+      authState: action.payload,
+    }),
+  },
+});
+
+export default accountSlice;

--- a/src/ducks/createStore.ts
+++ b/src/ducks/createStore.ts
@@ -2,13 +2,18 @@ import { Store, combineReducers } from 'redux';
 import logger from 'redux-logger';
 import { configureStore, getDefaultMiddleware } from '@reduxjs/toolkit';
 import counterSlice, { initialState as counterState } from './counter/slice';
+import accountSlice, { initialState as accountState } from './account/slice';
 
 const rootReducer = combineReducers({
   counter: counterSlice.reducer,
+  account: accountSlice.reducer,
 });
 
 const preloadedState = () => {
-  return { counter: counterState };
+  return {
+    counter: counterState,
+    account: accountState,
+  };
 };
 
 export type StoreState = ReturnType<typeof preloadedState>;

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -13,7 +13,7 @@ import { useDispatch } from 'react-redux';
 import accountSlice from '../ducks/account/slice';
 import { useAccountState } from '../ducks/account/selectors';
 
-const AuthStateApp: React.FunctionComponent = () => {
+const AccountPage: React.FunctionComponent = () => {
   const dispatch = useDispatch();
   const state = useAccountState().account;
 

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -64,4 +64,4 @@ const AuthStateApp: React.FunctionComponent = () => {
   );
 };
 
-export default AuthStateApp;
+export default AccountPage;

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -1,44 +1,26 @@
 import React from 'react';
-import {
-  AmplifyAuthenticator,
-  AmplifySignUp,
-  AmplifySignOut,
-} from '@aws-amplify/ui-react';
+import { AmplifyAuthenticator, AmplifySignOut } from '@aws-amplify/ui-react';
+import { AuthState, onAuthUIStateChange } from '@aws-amplify/ui-components';
 
-const IndexPage: React.FC = () => {
-  return (
-    <AmplifyAuthenticator>
-      <AmplifySignUp
-        headerText="Sign Up"
-        slot="sign-up"
-        usernameAlias="username"
-        formFields={[
-          {
-            type: 'username',
-            label: 'ユーザ名(必須)',
-            placeholder: '',
-            required: true,
-          },
-          {
-            type: 'email',
-            label: 'メールアドレス(必須)',
-            placeholder: '',
-            required: true,
-          },
-          {
-            type: 'password',
-            label: 'パスワード(必須)',
-            placeholder: '',
-            required: true,
-          },
-        ]}
-      />
-      <div>
-        Kimono APP
-        <AmplifySignOut />
-      </div>
-    </AmplifyAuthenticator>
+const AuthStateApp: React.FunctionComponent = () => {
+  const [authState, setAuthState] = React.useState<AuthState>();
+  const [user, setUser] = React.useState<object | undefined>();
+
+  React.useEffect(() => {
+    return onAuthUIStateChange((nextAuthState, authData) => {
+      setAuthState(nextAuthState);
+      setUser(authData);
+    });
+  }, []);
+
+  return authState === AuthState.SignedIn && user ? (
+    <div className="App">
+      <div>Hello, {user.username}</div>
+      <AmplifySignOut />
+    </div>
+  ) : (
+    <AmplifyAuthenticator />
   );
 };
 
-export default IndexPage;
+export default AuthStateApp;

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,6 +196,14 @@
   dependencies:
     qrcode "^1.4.4"
 
+"@aws-amplify/ui-components@^0.5.4":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/ui-components/-/ui-components-0.5.4.tgz#491c7e1883364c56a8fabbb092fe4f61f102eb82"
+  integrity sha512-9wyN89yjlMJWyIncvqhPrA3whVgAKTvT46/saxN7RbT8CsEv5yTVX+F6IULIXVsOiFzdEocbLe0MlmV9X6aKpw==
+  dependencies:
+    qrcode "^1.4.4"
+    uuid "^8.2.0"
+
 "@aws-amplify/ui-react@^0.2.9":
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/@aws-amplify/ui-react/-/ui-react-0.2.9.tgz#f5e1f81f99728d1b2a359cd1435d32402fe9fe9b"
@@ -16985,6 +16993,11 @@ uuid@^7.0.0, uuid@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+
+uuid@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.2.0.tgz#cb10dd6b118e2dada7d0cd9730ba7417c93d920e"
+  integrity sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==
 
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-frontend/issues/5

# 関連URL
http://localhost:3000/account

# Doneの定義
https://github.com/nekochans/kimono-app-frontend/issues/5 の完了の定義が満たされていること

# スクリーンショット
ログイン画面(デフォルトの画面を使用)
<img width="468" alt="スクリーンショット 2020-07-27 15 18 20" src="https://user-images.githubusercontent.com/32682645/88512491-a214ed00-d021-11ea-92f9-f988573173ba.png">

ログイン後の画面(ユーザ名を表示)
<img width="1440" alt="スクリーンショット 2020-07-27 15 17 50" src="https://user-images.githubusercontent.com/32682645/88512512-a7723780-d021-11ea-9ecd-9c9f6345ac2b.png">


# 変更点概要
- ログイン機能を実現するため下記のパッケージを追加
`@aws-amplify/ui-components`

参考：下記はVueのページ。以前はこれ相当のReactのページが存在したが、現在は消えている様子
(なぜドキュメントが消えたのかは調査中)
https://docs.amplify.aws/ui/auth/authenticator/q/framework/vue#manage-auth-state-and-conditional-app-rendering

- Reduxにユーザ情報を保持
現時点ではログインに必要な最低限の情報のみをstateに設定している
 