### PR TITLE
GitHub Actionsにyarnのcacheを追加

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -32,7 +32,6 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - run: |
-          npm install -g yarn
           yarn install
           yarn run build
           yarn run lint

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -18,12 +18,26 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - run: |
           npm install -g yarn
           yarn install
           yarn run build
           yarn run lint
           yarn run test:ci
+
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-frontend/issues/30

# Doneの定義
https://github.com/nekochans/kimono-app-frontend/issues/30 の完了の定義が満たされていること

# 変更点概要
- GitHub Actionsにyarnのcacheを追加
- npmでyarnをインストールしている箇所を削除
ubuntu-latestにはyarnがインストールされているため
https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md

cache設定前
<img width="1129" alt="スクリーンショット 2020-08-11 21 02 35" src="https://user-images.githubusercontent.com/32682645/89901153-aba47480-dc1f-11ea-99ce-1a977a3fd664.png">

cache設定後(初回)
https://github.com/nekochans/kimono-app-frontend/runs/971060259?check_suite_focus=true
- cacheが存在しないため`Cache not found for input keys: Linux-yarn-f6f4471adcddc6fe336cdc8fa136d9c1d2a7588c98c82eb37fa68f0b89394faf, Linux-yarn-`となっている。
- 最後にcacheが保存されている
<img width="1130" alt="スクリーンショット 2020-08-11 21 06 10" src="https://user-images.githubusercontent.com/32682645/89901231-c5de5280-dc1f-11ea-831c-f9cdf0d9c68f.png">

cache設定後(2回目)
https://github.com/nekochans/kimono-app-frontend/runs/971078212?check_suite_focus=true
- cacheが存在するため復元される
`Cache restored from key: Linux-yarn-f6f4471adcddc6fe336cdc8fa136d9c1d2a7588c98c82eb37fa68f0b89394faf`
- cacheが存在するのでジョブの最後で上書きされずに終了している
<img width="1131" alt="スクリーンショット 2020-08-11 21 12 02" src="https://user-images.githubusercontent.com/32682645/89901839-a72c8b80-dc20-11ea-9427-30642bbd51ec.png">
