### PR TITLE
GitHub Actionsのjobにタイムアウトを設定

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     name: Build And Test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [12.x]


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-frontend/issues/28

# Doneの定義
https://github.com/nekochans/kimono-app-frontend/issues/28 の完了条件が満たされていること

# 変更点概要
GitHub Actionsにタイムアウトを設定
Step単位でも設定できるが細かく設定する意味もあまりないのでJob単位で設定している
時間は少し長めの10分を設定した