### PR TITLE
アカウント登録を完了させるエンドポイントを実装

### DIFF
--- a/src/pages/accounts/create/confirm.tsx
+++ b/src/pages/accounts/create/confirm.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { GetServerSideProps } from 'next';
+import { Auth } from 'aws-amplify';
+
+type Props = {
+  user: { sub: string };
+  error: Error;
+};
+
+const AccountCreateConfirmPage: React.FC<Props> = ({ user, error }: Props) => {
+  // TODO ちゃんとしたエラー表示用のComponentを作成して表示させる
+  return (
+    <>
+      {error ? <div>エラーが発生しました。 {error.message}</div> : ''}
+      {user ? <div>アカウント登録が完了しました！ {user.sub}</div> : ''}
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  try {
+    const { sub, code } = context.query;
+
+    if (sub === undefined || code === undefined) {
+      return {
+        props: {},
+      };
+    }
+
+    // 返り値はSUCCESSという文字列が返ってくるだけ
+    await Auth.confirmSignUp(String(sub), String(code));
+
+    return { props: { user: { sub } } };
+  } catch (e) {
+    return { props: { error: e } };
+  }
+};
+
+export default AccountCreateConfirmPage;


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-frontend/issues/34

# 関連URL
http://localhost:3100/accounts/create/confirm?code=000000&sub=xxxx-xxxx-xxxx-xxxx

# Doneの定義
- アカウント登録が完了出来るエンドポイントが実装されている事

# スクリーンショット
今は仮実装なので、以下のように表示させるだけ。

<img width="608" alt="confirm" src="https://user-images.githubusercontent.com/11032365/93707098-df4fb400-fb66-11ea-8276-fe6c9796b4e9.png">

# 変更点概要
- `/accounts/create/confirm` ページを実装

※ `getServerSideProps` を実行しているので、サーバーサイドでのルーティングでしかこのエンドポイントにアクセスする事が出来ないが、メールのリンクからこのページにアクセスしてくるので、 `getServerSideProps` で問題がないと思っている。

# 補足情報
アカウント登録のメール内容を https://github.com/nekochans/kimono-app-cognito-lambda/issues/3 で変更しており、本PRで実装したエンドポイントに誘導するようにしてある。