### PR TITLE
パスワードリセットフォームを @aws-amplify/ui-react を使わない形で実装

### DIFF
--- a/src/domain/Cognito.ts
+++ b/src/domain/Cognito.ts
@@ -15,3 +15,9 @@ export type LoginRequest = {
 export type PasswordResetRequest = {
   email: string;
 };
+
+export type PasswordResetConfirmRequest = {
+  newPassword: string;
+  confirmationCode: string;
+  cognitoUserName: string;
+};

--- a/src/domain/Cognito.ts
+++ b/src/domain/Cognito.ts
@@ -11,3 +11,7 @@ export type LoginRequest = {
   email: string;
   password: string;
 };
+
+export type PasswordResetRequest = {
+  email: string;
+};

--- a/src/domain/error/PasswordAttemptsExceeded.ts
+++ b/src/domain/error/PasswordAttemptsExceeded.ts
@@ -1,3 +1,0 @@
-import ExtensibleCustomError from 'extensible-custom-error';
-
-export default class PasswordAttemptsExceeded extends ExtensibleCustomError {}

--- a/src/domain/error/PasswordAttemptsExceededError.ts
+++ b/src/domain/error/PasswordAttemptsExceededError.ts
@@ -1,0 +1,3 @@
+import ExtensibleCustomError from 'extensible-custom-error';
+
+export default class PasswordAttemptsExceededError extends ExtensibleCustomError {}

--- a/src/domain/error/PasswordResetConfirmError.ts
+++ b/src/domain/error/PasswordResetConfirmError.ts
@@ -1,0 +1,3 @@
+import ExtensibleCustomError from 'extensible-custom-error';
+
+export default class PasswordResetConfirmError extends ExtensibleCustomError {}

--- a/src/domain/error/PasswordResetRequestError.ts
+++ b/src/domain/error/PasswordResetRequestError.ts
@@ -1,0 +1,3 @@
+import ExtensibleCustomError from 'extensible-custom-error';
+
+export default class PasswordResetRequestError extends ExtensibleCustomError {}

--- a/src/ducks/cognito/asyncActions.ts
+++ b/src/ducks/cognito/asyncActions.ts
@@ -12,7 +12,7 @@ import CreateAccountUnexpectedError from '../../domain/error/CreateAccountUnexpe
 import ResendCreateAccountRequestUnexpectedError from '../../domain/error/ResendCreateAccountRequestUnexpectedError';
 import NotConfirmedError from '../../domain/error/NotConfirmedError';
 import LoginUnexpectedError from '../../domain/error/LoginUnexpectedError';
-import PasswordAttemptsExceeded from '../../domain/error/PasswordAttemptsExceeded';
+import PasswordAttemptsExceededError from '../../domain/error/PasswordAttemptsExceededError';
 import WrongCredentialsError from '../../domain/error/WrongCredentialsError';
 import PasswordResetRequestError from '../../domain/error/PasswordResetRequestError';
 import PasswordResetConfirmError from '../../domain/error/PasswordResetConfirmError';
@@ -66,7 +66,7 @@ export const loginRequest = createAsyncThunk<void, LoginRequest>(
         e.code === 'NotAuthorizedException' &&
         e.message === 'Password attempts exceeded'
       ) {
-        throw new PasswordAttemptsExceeded(e.message, e);
+        throw new PasswordAttemptsExceededError(e.message, e);
       }
 
       if (e.code === 'NotAuthorizedException') {

--- a/src/ducks/cognito/asyncActions.ts
+++ b/src/ducks/cognito/asyncActions.ts
@@ -4,6 +4,7 @@ import {
   CreateAccountRequest,
   ResendCreateAccountRequest,
   LoginRequest,
+  PasswordResetRequest,
 } from '../../domain/Cognito';
 import AccountAlreadyExistsError from '../../domain/error/AccountAlreadyExistsError';
 import CreateAccountUnexpectedError from '../../domain/error/CreateAccountUnexpectedError';
@@ -12,6 +13,7 @@ import NotConfirmedError from '../../domain/error/NotConfirmedError';
 import LoginUnexpectedError from '../../domain/error/LoginUnexpectedError';
 import PasswordAttemptsExceeded from '../../domain/error/PasswordAttemptsExceeded';
 import WrongCredentialsError from '../../domain/error/WrongCredentialsError';
+import PasswordResetRequestError from '../../domain/error/PasswordResetRequestError';
 
 export const createAccountRequest = createAsyncThunk<
   void,
@@ -73,3 +75,14 @@ export const loginRequest = createAsyncThunk<void, LoginRequest>(
     }
   },
 );
+
+export const passwordResetRequest = createAsyncThunk<
+  void,
+  PasswordResetRequest
+>('cognito/passwordResetRequest', async (arg: PasswordResetRequest) => {
+  try {
+    await Auth.forgotPassword(arg.email);
+  } catch (e) {
+    throw new PasswordResetRequestError(e.message, e);
+  }
+});

--- a/src/ducks/cognito/asyncActions.ts
+++ b/src/ducks/cognito/asyncActions.ts
@@ -5,6 +5,7 @@ import {
   ResendCreateAccountRequest,
   LoginRequest,
   PasswordResetRequest,
+  PasswordResetConfirmRequest,
 } from '../../domain/Cognito';
 import AccountAlreadyExistsError from '../../domain/error/AccountAlreadyExistsError';
 import CreateAccountUnexpectedError from '../../domain/error/CreateAccountUnexpectedError';
@@ -14,6 +15,7 @@ import LoginUnexpectedError from '../../domain/error/LoginUnexpectedError';
 import PasswordAttemptsExceeded from '../../domain/error/PasswordAttemptsExceeded';
 import WrongCredentialsError from '../../domain/error/WrongCredentialsError';
 import PasswordResetRequestError from '../../domain/error/PasswordResetRequestError';
+import PasswordResetConfirmError from '../../domain/error/PasswordResetConfirmError';
 
 export const createAccountRequest = createAsyncThunk<
   void,
@@ -86,3 +88,21 @@ export const passwordResetRequest = createAsyncThunk<
     throw new PasswordResetRequestError(e.message, e);
   }
 });
+
+export const passwordResetConfirmRequest = createAsyncThunk<
+  void,
+  PasswordResetConfirmRequest
+>(
+  'cognito/passwordResetConfirmRequest',
+  async (arg: PasswordResetConfirmRequest) => {
+    try {
+      await Auth.forgotPasswordSubmit(
+        arg.cognitoUserName,
+        arg.confirmationCode,
+        arg.newPassword,
+      );
+    } catch (e) {
+      throw new PasswordResetConfirmError(e.message, e);
+    }
+  },
+);

--- a/src/ducks/cognito/slice.ts
+++ b/src/ducks/cognito/slice.ts
@@ -2,11 +2,13 @@ import { createSlice } from '@reduxjs/toolkit';
 import {
   createAccountRequest,
   loginRequest,
+  passwordResetRequest,
   resendCreateAccountRequest,
 } from './asyncActions';
 import {
   CreateAccountRequest,
   LoginRequest,
+  PasswordResetRequest,
   ResendCreateAccountRequest,
 } from '../../domain/Cognito';
 
@@ -18,6 +20,7 @@ export type CognitoState = {
   successfulAccountCreateRequest: boolean;
   successfulResendAccountCreateRequest: boolean;
   successfulLoginRequest: boolean;
+  successfulPasswordResetRequest: boolean;
   sentEmail: string;
 };
 
@@ -29,6 +32,7 @@ export const initialState: CognitoState = {
   successfulAccountCreateRequest: false,
   successfulResendAccountCreateRequest: false,
   successfulLoginRequest: false,
+  successfulPasswordResetRequest: false,
   sentEmail: '',
 };
 
@@ -47,6 +51,7 @@ const cognitoSlice = createSlice({
         successfulAccountCreateRequest: false,
         successfulResendAccountCreateRequest: false,
         successfulLoginRequest: false,
+        successfulPasswordResetRequest: false,
         sentEmail: '',
       };
     });
@@ -62,6 +67,7 @@ const cognitoSlice = createSlice({
           successfulAccountCreateRequest: false,
           successfulResendAccountCreateRequest: false,
           successfulLoginRequest: false,
+          successfulPasswordResetRequest: false,
           sentEmail: '',
         };
       },
@@ -76,6 +82,7 @@ const cognitoSlice = createSlice({
         successfulAccountCreateRequest: true,
         successfulResendAccountCreateRequest: false,
         successfulLoginRequest: false,
+        successfulPasswordResetRequest: false,
         sentEmail: action.meta.arg.email,
       };
     });
@@ -88,6 +95,7 @@ const cognitoSlice = createSlice({
         successfulAccountCreateRequest: false,
         successfulResendAccountCreateRequest: false,
         successfulLoginRequest: false,
+        successfulPasswordResetRequest: false,
         sentEmail: '',
       };
     });
@@ -103,6 +111,7 @@ const cognitoSlice = createSlice({
           successfulAccountCreateRequest: false,
           successfulResendAccountCreateRequest: false,
           successfulLoginRequest: false,
+          successfulPasswordResetRequest: false,
           sentEmail: '',
         };
       },
@@ -114,6 +123,7 @@ const cognitoSlice = createSlice({
         successfulAccountCreateRequest: false,
         successfulResendAccountCreateRequest: true,
         successfulLoginRequest: false,
+        successfulPasswordResetRequest: false,
         sentEmail: action.meta.arg.email,
       };
     });
@@ -126,10 +136,11 @@ const cognitoSlice = createSlice({
         errorMessage: '',
         successfulAccountCreateRequest: false,
         successfulResendAccountCreateRequest: false,
+        successfulLoginRequest: false,
+        successfulPasswordResetRequest: false,
         sentEmail: '',
       };
     });
-
     builder.addCase(
       loginRequest.rejected,
       (state, action: RejectedAction<LoginRequest>) => {
@@ -142,6 +153,7 @@ const cognitoSlice = createSlice({
           successfulAccountCreateRequest: false,
           successfulResendAccountCreateRequest: false,
           successfulLoginRequest: false,
+          successfulPasswordResetRequest: false,
           sentEmail: '',
         };
       },
@@ -156,7 +168,53 @@ const cognitoSlice = createSlice({
         successfulAccountCreateRequest: false,
         successfulResendAccountCreateRequest: false,
         successfulLoginRequest: true,
+        successfulPasswordResetRequest: false,
         sentEmail: '',
+      };
+    });
+    builder.addCase(passwordResetRequest.pending, (state) => {
+      return {
+        ...state,
+        loading: true,
+        error: false,
+        errorName: '',
+        errorMessage: '',
+        successfulAccountCreateRequest: false,
+        successfulResendAccountCreateRequest: false,
+        successfulLoginRequest: false,
+        successfulPasswordResetRequest: false,
+        sentEmail: '',
+      };
+    });
+    builder.addCase(
+      passwordResetRequest.rejected,
+      (state, action: RejectedAction<PasswordResetRequest>) => {
+        return {
+          ...state,
+          loading: false,
+          error: true,
+          errorName: action.error.name,
+          errorMessage: action.error.message,
+          successfulAccountCreateRequest: false,
+          successfulResendAccountCreateRequest: false,
+          successfulLoginRequest: false,
+          successfulPasswordResetRequest: false,
+          sentEmail: '',
+        };
+      },
+    );
+    builder.addCase(passwordResetRequest.fulfilled, (state, action) => {
+      return {
+        ...state,
+        loading: false,
+        error: false,
+        errorName: '',
+        errorMessage: '',
+        successfulAccountCreateRequest: false,
+        successfulResendAccountCreateRequest: false,
+        successfulLoginRequest: false,
+        successfulPasswordResetRequest: true,
+        sentEmail: action.meta.arg.email,
       };
     });
   },

--- a/src/ducks/cognito/slice.ts
+++ b/src/ducks/cognito/slice.ts
@@ -2,12 +2,14 @@ import { createSlice } from '@reduxjs/toolkit';
 import {
   createAccountRequest,
   loginRequest,
+  passwordResetConfirmRequest,
   passwordResetRequest,
   resendCreateAccountRequest,
 } from './asyncActions';
 import {
   CreateAccountRequest,
   LoginRequest,
+  PasswordResetConfirmRequest,
   PasswordResetRequest,
   ResendCreateAccountRequest,
 } from '../../domain/Cognito';
@@ -21,6 +23,7 @@ export type CognitoState = {
   successfulResendAccountCreateRequest: boolean;
   successfulLoginRequest: boolean;
   successfulPasswordResetRequest: boolean;
+  successfulPasswordResetConfirm: boolean;
   sentEmail: string;
 };
 
@@ -33,6 +36,7 @@ export const initialState: CognitoState = {
   successfulResendAccountCreateRequest: false,
   successfulLoginRequest: false,
   successfulPasswordResetRequest: false,
+  successfulPasswordResetConfirm: false,
   sentEmail: '',
 };
 
@@ -52,6 +56,7 @@ const cognitoSlice = createSlice({
         successfulResendAccountCreateRequest: false,
         successfulLoginRequest: false,
         successfulPasswordResetRequest: false,
+        successfulPasswordResetConfirm: false,
         sentEmail: '',
       };
     });
@@ -68,6 +73,7 @@ const cognitoSlice = createSlice({
           successfulResendAccountCreateRequest: false,
           successfulLoginRequest: false,
           successfulPasswordResetRequest: false,
+          successfulPasswordResetConfirm: false,
           sentEmail: '',
         };
       },
@@ -83,6 +89,7 @@ const cognitoSlice = createSlice({
         successfulResendAccountCreateRequest: false,
         successfulLoginRequest: false,
         successfulPasswordResetRequest: false,
+        successfulPasswordResetConfirm: false,
         sentEmail: action.meta.arg.email,
       };
     });
@@ -96,6 +103,7 @@ const cognitoSlice = createSlice({
         successfulResendAccountCreateRequest: false,
         successfulLoginRequest: false,
         successfulPasswordResetRequest: false,
+        successfulPasswordResetConfirm: false,
         sentEmail: '',
       };
     });
@@ -112,6 +120,7 @@ const cognitoSlice = createSlice({
           successfulResendAccountCreateRequest: false,
           successfulLoginRequest: false,
           successfulPasswordResetRequest: false,
+          successfulPasswordResetConfirm: false,
           sentEmail: '',
         };
       },
@@ -124,6 +133,7 @@ const cognitoSlice = createSlice({
         successfulResendAccountCreateRequest: true,
         successfulLoginRequest: false,
         successfulPasswordResetRequest: false,
+        successfulPasswordResetConfirm: false,
         sentEmail: action.meta.arg.email,
       };
     });
@@ -138,6 +148,7 @@ const cognitoSlice = createSlice({
         successfulResendAccountCreateRequest: false,
         successfulLoginRequest: false,
         successfulPasswordResetRequest: false,
+        successfulPasswordResetConfirm: false,
         sentEmail: '',
       };
     });
@@ -154,6 +165,7 @@ const cognitoSlice = createSlice({
           successfulResendAccountCreateRequest: false,
           successfulLoginRequest: false,
           successfulPasswordResetRequest: false,
+          successfulPasswordResetConfirm: false,
           sentEmail: '',
         };
       },
@@ -169,6 +181,7 @@ const cognitoSlice = createSlice({
         successfulResendAccountCreateRequest: false,
         successfulLoginRequest: true,
         successfulPasswordResetRequest: false,
+        successfulPasswordResetConfirm: false,
         sentEmail: '',
       };
     });
@@ -183,6 +196,7 @@ const cognitoSlice = createSlice({
         successfulResendAccountCreateRequest: false,
         successfulLoginRequest: false,
         successfulPasswordResetRequest: false,
+        successfulPasswordResetConfirm: false,
         sentEmail: '',
       };
     });
@@ -199,6 +213,7 @@ const cognitoSlice = createSlice({
           successfulResendAccountCreateRequest: false,
           successfulLoginRequest: false,
           successfulPasswordResetRequest: false,
+          successfulPasswordResetConfirm: false,
           sentEmail: '',
         };
       },
@@ -214,7 +229,56 @@ const cognitoSlice = createSlice({
         successfulResendAccountCreateRequest: false,
         successfulLoginRequest: false,
         successfulPasswordResetRequest: true,
+        successfulPasswordResetConfirm: false,
         sentEmail: action.meta.arg.email,
+      };
+    });
+    builder.addCase(passwordResetConfirmRequest.pending, (state) => {
+      return {
+        ...state,
+        loading: true,
+        error: false,
+        errorName: '',
+        errorMessage: '',
+        successfulAccountCreateRequest: false,
+        successfulResendAccountCreateRequest: false,
+        successfulLoginRequest: false,
+        successfulPasswordResetRequest: false,
+        successfulPasswordResetConfirm: false,
+        sentEmail: '',
+      };
+    });
+    builder.addCase(
+      passwordResetConfirmRequest.rejected,
+      (state, action: RejectedAction<PasswordResetConfirmRequest>) => {
+        return {
+          ...state,
+          loading: false,
+          error: true,
+          errorName: action.error.name,
+          errorMessage: action.error.message,
+          successfulAccountCreateRequest: false,
+          successfulResendAccountCreateRequest: false,
+          successfulLoginRequest: false,
+          successfulPasswordResetRequest: false,
+          successfulPasswordResetConfirm: false,
+          sentEmail: '',
+        };
+      },
+    );
+    builder.addCase(passwordResetConfirmRequest.fulfilled, (state) => {
+      return {
+        ...state,
+        loading: false,
+        error: false,
+        errorName: '',
+        errorMessage: '',
+        successfulAccountCreateRequest: false,
+        successfulResendAccountCreateRequest: false,
+        successfulLoginRequest: false,
+        successfulPasswordResetRequest: false,
+        successfulPasswordResetConfirm: true,
+        sentEmail: '',
       };
     });
   },

--- a/src/pages/accounts/create/confirm.tsx
+++ b/src/pages/accounts/create/confirm.tsx
@@ -38,7 +38,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     // 返り値はSUCCESSという文字列が返ってくるだけ
     await Auth.confirmSignUp(String(userName), String(code));
 
-    return { props: { user: { userName } } };
+    return { props: { user: { cognitoUserName: userName } } };
   } catch (e) {
     return { props: { error: e } };
   }

--- a/src/pages/accounts/create/confirm.tsx
+++ b/src/pages/accounts/create/confirm.tsx
@@ -4,7 +4,7 @@ import { Auth } from 'aws-amplify';
 import Link from 'next/link';
 
 type Props = {
-  user: { sub: string };
+  user: { cognitoUserName: string };
   error: Error;
 };
 
@@ -15,8 +15,8 @@ const AccountCreateConfirmPage: React.FC<Props> = ({ user, error }: Props) => {
       {error ? <div>エラーが発生しました。 {error.message}</div> : ''}
       {user ? (
         <div>
-          アカウント登録が完了しました！ アカウントIDは {user.sub} です！{' '}
-          <Link href="/login">ログイン</Link> を行って下さい！
+          アカウント登録が完了しました！ アカウントIDは {user.cognitoUserName}{' '}
+          です！ <Link href="/login">ログイン</Link> を行って下さい！
         </div>
       ) : (
         ''
@@ -27,18 +27,18 @@ const AccountCreateConfirmPage: React.FC<Props> = ({ user, error }: Props) => {
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   try {
-    const { sub, code } = context.query;
+    const { userName, code } = context.query;
 
-    if (sub === undefined || code === undefined) {
+    if (userName === undefined || code === undefined) {
       return {
         props: {},
       };
     }
 
     // 返り値はSUCCESSという文字列が返ってくるだけ
-    await Auth.confirmSignUp(String(sub), String(code));
+    await Auth.confirmSignUp(String(userName), String(code));
 
-    return { props: { user: { sub } } };
+    return { props: { user: { userName } } };
   } catch (e) {
     return { props: { error: e } };
   }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
+import Link from 'next/link';
 import { useCognitoState } from '../ducks/cognito/selectors';
 import {
   loginRequest,
@@ -62,6 +63,9 @@ const LoginPage: React.FC = () => {
         <button type="button" onClick={handleLoginSubmit}>
           ログイン
         </button>
+        <p>
+          <Link href="/password/reset">パスワードを忘れた方はこちら</Link>
+        </p>
         {state.errorName === 'NotConfirmedError' ? (
           <button type="button" onClick={handleResendCreateAccountSubmit}>
             認証メールを再送信する

--- a/src/pages/password/reset.tsx
+++ b/src/pages/password/reset.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { useCognitoState } from '../../ducks/cognito/selectors';
+import { passwordResetRequest } from '../../ducks/cognito/asyncActions';
+
+const PasswordResetPage: React.FC = () => {
+  const dispatch = useDispatch();
+  const state = useCognitoState();
+
+  const [email, setEmail] = React.useState<string>('');
+
+  const changedEmailHandler = (event: React.ChangeEvent<HTMLInputElement>) =>
+    setEmail(event.target.value.trim());
+
+  const handlePasswordResetSubmit = async () => {
+    if (!email) {
+      return;
+    }
+
+    await dispatch(passwordResetRequest({ email }));
+  };
+
+  const inputStyle = {
+    width: 300,
+    height: 25,
+  };
+
+  const errorStyle = {
+    color: 'red',
+  };
+
+  return (
+    <>
+      <h1>パスワードをリセットする</h1>
+      <form method="post">
+        <input
+          type="text"
+          placeholder="email"
+          onChange={changedEmailHandler}
+          style={inputStyle}
+        />
+        <button type="button" onClick={handlePasswordResetSubmit}>
+          パスワードリセット用のリンクを送信する
+        </button>
+      </form>
+      {state.successfulPasswordResetRequest ? (
+        <div>
+          {state.sentEmail}{' '}
+          にパスワードリセット用の認証メールを送信しました。メールをご確認下さい。
+        </div>
+      ) : (
+        ''
+      )}
+      {state.error ? <div style={errorStyle}>{state.errorMessage}</div> : ''}
+    </>
+  );
+};
+
+export default PasswordResetPage;

--- a/src/pages/password/reset/confirm.tsx
+++ b/src/pages/password/reset/confirm.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import Link from 'next/link';
+import { GetServerSideProps } from 'next';
+import { useDispatch } from 'react-redux';
+import { useCognitoState } from '../../../ducks/cognito/selectors';
+import { passwordResetConfirmRequest } from '../../../ducks/cognito/asyncActions';
+
+type Props = {
+  user: { cognitoUserName: string };
+  confirmationCode: string;
+};
+
+const PasswordResetConfirmPage: React.FC<Props> = ({
+  user,
+  confirmationCode,
+}: Props) => {
+  const dispatch = useDispatch();
+  const state = useCognitoState();
+
+  const [newPassword, setNewPassword] = React.useState<string>('');
+
+  const changedNewPasswordHandler = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => setNewPassword(event.target.value.trim());
+
+  const handleNewPasswordSubmit = async () => {
+    if (!user?.cognitoUserName || !confirmationCode || !newPassword) {
+      // TODO ここでreturnすると不具合があった際に分かりにくいのでエラー用Componentを表示させる
+      return;
+    }
+
+    await dispatch(
+      passwordResetConfirmRequest({
+        cognitoUserName: user.cognitoUserName,
+        confirmationCode,
+        newPassword,
+      }),
+    );
+  };
+
+  const inputStyle = {
+    width: 250,
+    height: 25,
+  };
+
+  const errorStyle = {
+    color: 'red',
+  };
+
+  // TODO ちゃんとしたエラー表示用のComponentを作成して表示させる
+  return (
+    <>
+      <h1>パスワードリセットを完了させる</h1>
+      <form method="post">
+        <input
+          style={inputStyle}
+          type="password"
+          placeholder="新しいパスワード"
+          onChange={changedNewPasswordHandler}
+        />
+        <button type="button" onClick={handleNewPasswordSubmit}>
+          パスワードリセットを完了させる
+        </button>
+      </form>
+      {state.error ? <div style={errorStyle}>{state.errorMessage}</div> : ''}
+      {state.error || state.errorMessage ? (
+        <Link href="/password/reset">パスワードリセットを最初からやり直す</Link>
+      ) : (
+        ''
+      )}
+      {state.successfulPasswordResetConfirm ? (
+        <div>
+          新しいパスワードに変更しました。{' '}
+          <Link href="/login">ログインページ</Link> からログインを行って下さい。
+        </div>
+      ) : (
+        ''
+      )}
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { userName, code } = context.query;
+
+  if (userName === undefined || code === undefined) {
+    return {
+      props: {},
+    };
+  }
+
+  return {
+    props: { user: { cognitoUserName: userName }, confirmationCode: code },
+  };
+};
+
+export default PasswordResetConfirmPage;


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-frontend/issues/36

# 関連URL
http://localhost:3100/password/reset/confirm?code=000000&userName=08cc3e74-6ce4-4006-9c3f-ae4e0b8cac78

# Doneの定義
- パスワードのリセット機能が完成している事

# スクリーンショット

パスワードリセットまでの流れと共にスクショを添付。

1. http://localhost:3100/password/reset からパスワードリセット用のリンクを送信


2. メールに記載されているリンクに遷移する（リンク先はこのPRで作成したページ）

メッセージのカスタマイズは https://github.com/nekochans/kimono-app-cognito-lambda/issues/6 で実施。

![passwordResetMail](https://user-images.githubusercontent.com/11032365/96359993-ae59a380-1153-11eb-97fd-fb0580b45da2.png)

3. 新しいパスワードを入力してパスワードリセットを完了させる

![passwordResetEnd](https://user-images.githubusercontent.com/11032365/96359994-b4e81b00-1153-11eb-9325-89940d683f7f.png)

# 変更点概要
確認コードと新しいパスワードを受け取り、パスワードをリセットするFormとReduxActionを実装。


# 補足情報
このPRの趣旨とは異なるが以下の変更も行った。

- https://github.com/nekochans/kimono-app-cognito-lambda/issues/6 でカスタムメッセージに設定するクエリパラメータ名をsubからuserNameに変えたので対応（userNameのほうが適切なため）
- ErrorクラスのsuffixにErrorがないクラスがあったので修正

https://github.com/nekochans/kimono-app-cognito-lambda/pull/6 と依存関係があるので同時にマージする必要がある。