### PR TITLE
ログアウトの実装

### DIFF
--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -6,5 +6,6 @@ export const urlList = {
   top: appBaseUrl(),
   createAccount: `${appBaseUrl()}/accounts/create`,
   login: `${appBaseUrl()}/login`,
+  logout: `${appBaseUrl()}/logout`,
   my: `${appBaseUrl()}/my`,
 } as const;

--- a/src/pages/logout.tsx
+++ b/src/pages/logout.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect } from 'react';
+import { Auth } from 'aws-amplify';
+import { useDispatch } from 'react-redux';
+import { useRouter } from 'next/router';
+import cognitoSlice from '../redux/cognito/slice';
+import { urlList } from '../constants/url';
+
+const LogoutPage: React.FC = () => {
+  const dispatch = useDispatch();
+  const router = useRouter();
+
+  useEffect(() => {
+    let unmounted = false;
+
+    const logout = async () => {
+      try {
+        await Auth.signOut({ global: true });
+      } finally {
+        if (!unmounted) {
+          dispatch(cognitoSlice.actions.loggedOut());
+        }
+
+        await router.push(urlList.top);
+      }
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    logout();
+
+    return () => {
+      unmounted = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <>
+      <h1>🐱ログアウトしています🐱</h1>
+    </>
+  );
+};
+
+export default LogoutPage;

--- a/src/pages/my.tsx
+++ b/src/pages/my.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
+import Link from 'next/link';
 import { useMightAuthenticationRedirect } from '../hooks/useMightAuthenticationRedirect';
+import { urlList } from '../constants/url';
 
 const MyPage: React.FC = () => {
   const authenticatedState = useMightAuthenticationRedirect();
 
   return authenticatedState.authenticated ? (
-    <h1>🐱MyPage🐱</h1>
+    <>
+      <h1>🐱MyPage🐱</h1>
+      <Link href={urlList.logout}>ログアウト</Link>
+    </>
   ) : (
     <h1>通信中です</h1>
   );

--- a/src/redux/cognito/slice.ts
+++ b/src/redux/cognito/slice.ts
@@ -43,7 +43,23 @@ export const initialState: CognitoState = {
 const cognitoSlice = createSlice({
   name: 'cognito',
   initialState,
-  reducers: {},
+  reducers: {
+    loggedOut: (state) => {
+      return {
+        ...state,
+        loading: false,
+        error: false,
+        errorName: '',
+        errorMessage: '',
+        successfulAccountCreateRequest: false,
+        successfulResendAccountCreateRequest: false,
+        successfulLoginRequest: false,
+        successfulPasswordResetRequest: false,
+        successfulPasswordResetConfirm: false,
+        sentEmail: '',
+      };
+    },
+  },
   extraReducers: (builder) => {
     builder.addCase(createAccountRequest.pending, (state) => {
       return {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-frontend/issues/60

# 関連URL
http://localhost:3100/logout

# Doneの定義
- https://github.com/nekochans/kimono-app-frontend/issues/60 の完了の定義を満たしている事

# スクリーンショット

![logout](https://user-images.githubusercontent.com/11032365/104835517-a3e1ae00-58ea-11eb-8e75-4335a3c997af.png)

# 変更点概要
ログアウトページを作成しログアウト処理を実装。

例によってサーバーサイド側では上手く動作しなかったので、クライアントサイドで実装。

# 補足情報
検証の際にこの機能がないと色々と面倒なので早めに実施。